### PR TITLE
Ubuntu & Debian Support + Kitchen + Rubocop

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -13,10 +13,13 @@ verifier:
 
 platforms:
   - name: bento/debian-9.4
+  - name: bento/ubuntu-16.04
+  - name: bento/centos-7.4
 
 suites:
   - name: default
     run_list:
+      - recipe[proftpd-ii::force_ssh_keys]
       - recipe[proftpd-ii::example_lwrp]
     verifier:
       inspec_tests:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,24 @@
+---
+driver:
+  name: vagrant
+
+provisioner:
+  name: chef_zero
+  # You may wish to disable always updating cookbooks in CI or other testing environments.
+  # For example:
+  #   always_update_cookbooks: <%= !ENV['CI'] %>
+  always_update_cookbooks: true
+verifier:
+  name: inspec
+
+platforms:
+  - name: bento/debian-9.4
+
+suites:
+  - name: default
+    run_list:
+      - recipe[proftpd-ii::example_lwrp]
+    verifier:
+      inspec_tests:
+        - test/smoke/default
+    attributes:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,7 +13,7 @@ Vagrant.configure(2) do |config|
     centos6.vm.hostname = 'centos6'
     centos6.vm.provider 'docker' do |docker|
       docker.dockerfile = 'Dockerfile.centos6'
-      docker.ports = [ '6521:21', '6621:2121', '6522:2222' ]
+      docker.ports = ['6521:21', '6621:2121', '6522:2222']
     end
   end
 
@@ -22,8 +22,8 @@ Vagrant.configure(2) do |config|
     centos7.vm.hostname = 'centos7'
     centos7.vm.provider 'docker' do |docker|
       docker.dockerfile = 'Dockerfile.centos7'
-      docker.ports = [ '7521:21', '7621:2121', '7522:2222' ]
-      docker.volumes = [ '/sys/fs/cgroup:/sys/fs/cgroup:ro', "#{tempdir}:/run" ]
+      docker.ports = ['7521:21', '7621:2121', '7522:2222']
+      docker.volumes = ['/sys/fs/cgroup:/sys/fs/cgroup:ro', "#{tempdir}:/run"]
     end
   end
 
@@ -31,8 +31,8 @@ Vagrant.configure(2) do |config|
   config.omnibus.chef_version = '12.5.1'
 
   # run the example recipe
-  config.vm.provision "chef_solo" do |chef|
-    chef.add_recipe "proftpd-ii::example_lwrp"
+  config.vm.provision 'chef_solo' do |chef|
+    chef.add_recipe 'proftpd-ii::example_lwrp'
     chef.log_level = :info
     chef.formatter = 'doc'
     chef.json = {

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -51,8 +51,8 @@ default['proftpd-ii']['user_dir'] = '/var/lib/ftp'
 default['proftpd-ii']['user_shell'] = '/sbin/nologin'
 
 # What modules will we configure and load?
-default['proftpd-ii']['basic_modules'] = %w()
-default['proftpd-ii']['extra_modules'] = %w()
+default['proftpd-ii']['basic_modules'] = %w[]
+default['proftpd-ii']['extra_modules'] = %w[]
 
 # When a client connects, how do we name ourselves?
 default['proftpd-ii']['server_name'] = 'ProFTPD server'
@@ -93,7 +93,7 @@ default['proftpd-ii']['fxp'] = false
 
 # The authentication module order. ProFTPd will look at each authentication
 # module and try using the defined order. See ProFTPd's documentation for
-# more detailed info. 
+# more detailed info.
 default['proftpd-ii']['auth_order'] = 'mod_auth_pam.c mod_auth_unix.c'
 
 # Do we allow root logins?
@@ -146,7 +146,7 @@ default['proftpd-ii']['list_options'] = '-a'
 # RFC2228 multiline response mode
 default['proftpd-ii']['rfc2228'] = false
 
-# Default log format 
+# Default log format
 default['proftpd-ii']['log_format_default'] = '%h %l %u %t \"%r\" %s %b'
 
 # Authentication log format
@@ -160,3 +160,5 @@ default['proftpd-ii']['tls_ciphers'] = 'ALL:!ADH:!EXPORT56:RC4+RSA:+HIGH:+MEDIUM
 
 # use an user authorized keys file to permit users to login using keys
 default['proftpd-ii']['sftp_userauthorizedkeys'] = nil
+
+default['proftpd-ii']['sftp_hostkeys'] = ['/etc/ssh/ssh_host_rsa_key']

--- a/metadata.rb
+++ b/metadata.rb
@@ -11,7 +11,7 @@ source_url       'https://github.com/Movile/chef-proftpd-ii' if respond_to?(:sou
 
 recipe 'openresty', 'Installs proftpd from package and sets up configuration apache style sites-enabled/sites-available'
 
-%w(centos rhel amazon scientific oracle).each do |os|
+%w[centos rhel amazon scientific oracle].each do |os|
   supports os
 end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,13 +5,13 @@ license          'Apache 2.0'
 description      'Installs/Configures proftpd-ii'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 chef_version     '>= 11.0' if respond_to?(:chef_version)
-version          '0.5.5'
+version          '0.6.0'
 issues_url       'https://github.com/Movile/chef-proftpd-ii/issues' if respond_to?(:issues_url)
 source_url       'https://github.com/Movile/chef-proftpd-ii' if respond_to?(:source_url)
 
 recipe 'openresty', 'Installs proftpd from package and sets up configuration apache style sites-enabled/sites-available'
 
-%w[centos rhel amazon scientific oracle].each do |os|
+%w[centos rhel amazon scientific oracle ubuntu debian].each do |os|
   supports os
 end
 

--- a/providers/module.rb
+++ b/providers/module.rb
@@ -28,15 +28,15 @@ action :create do
   f = file "#{node['proftpd-ii']['conf_dir']}/mods-available/#{new_resource.name}.load" do
     owner node['proftpd-ii']['user']
     group node['proftpd-ii']['group']
-    mode 0644
+    mode 0o644
     content "LoadModule mod_#{new_resource.name}.c\n"
   end
 
   c = template "#{node['proftpd-ii']['conf_dir']}/mods-available/#{new_resource.name}.conf" do
     owner node['proftpd-ii']['user']
     group node['proftpd-ii']['group']
-    mode 0640
-    source [ "default/mods/#{new_resource.name}.conf.erb", "default/mods/generic.conf.erb" ]
+    mode 0o640
+    source ["default/mods/#{new_resource.name}.conf.erb", 'default/mods/generic.conf.erb']
   end
 
   if new_resource.enable

--- a/providers/vhost.rb
+++ b/providers/vhost.rb
@@ -28,33 +28,33 @@ action :create do
   f = template "#{node['proftpd-ii']['conf_dir']}/sites-available/#{new_resource.name}.conf" do
     owner node['proftpd-ii']['user']
     group node['proftpd-ii']['group']
-    mode 0640
+    mode 0o640
     variables(
-      :bind => new_resource.bind,
-      :auth_order => new_resource.auth_order,
-      :port => new_resource.port,
-      :default_server => new_resource.default_server,
-      :default_root => new_resource.default_root,
-      :debug_level => new_resource.debug_level,
-      :tls => new_resource.tls,
-      :tls_required => new_resource.tls_required,
-      :tls_cert => new_resource.tls_cert,
-      :tls_key => new_resource.tls_key,
-      :tls_chain => new_resource.tls_chain,
-      :tls_verify_client => new_resource.tls_verify_client,
-      :ldap => new_resource.ldap,
-      :ldap_use_tls => new_resource.ldap_use_tls,
-      :ldap_server => new_resource.ldap_server,
-      :ldap_bind_auth => new_resource.ldap_bind_auth,
-      :ldap_bind_dn => new_resource.ldap_bind_dn,
-      :ldap_bind_pass => new_resource.ldap_bind_pass,
-      :ldap_user_base_dn => new_resource.ldap_user_base_dn,
-      :ldap_user_filter => new_resource.ldap_user_filter,
-      :ldap_group_base_dn => new_resource.ldap_group_base_dn,
-      :ldap_group_filter => new_resource.ldap_group_filter,
-      :ldap_extra_options => new_resource.ldap_extra_options,
-      :sftp => new_resource.sftp,
-      :sftp_userauthorizedkeys => new_resource.sftp_userauthorizedkeys
+      bind: new_resource.bind,
+      auth_order: new_resource.auth_order,
+      port: new_resource.port,
+      default_server: new_resource.default_server,
+      default_root: new_resource.default_root,
+      debug_level: new_resource.debug_level,
+      tls: new_resource.tls,
+      tls_required: new_resource.tls_required,
+      tls_cert: new_resource.tls_cert,
+      tls_key: new_resource.tls_key,
+      tls_chain: new_resource.tls_chain,
+      tls_verify_client: new_resource.tls_verify_client,
+      ldap: new_resource.ldap,
+      ldap_use_tls: new_resource.ldap_use_tls,
+      ldap_server: new_resource.ldap_server,
+      ldap_bind_auth: new_resource.ldap_bind_auth,
+      ldap_bind_dn: new_resource.ldap_bind_dn,
+      ldap_bind_pass: new_resource.ldap_bind_pass,
+      ldap_user_base_dn: new_resource.ldap_user_base_dn,
+      ldap_user_filter: new_resource.ldap_user_filter,
+      ldap_group_base_dn: new_resource.ldap_group_base_dn,
+      ldap_group_filter: new_resource.ldap_group_filter,
+      ldap_extra_options: new_resource.ldap_extra_options,
+      sftp: new_resource.sftp,
+      sftp_userauthorizedkeys: new_resource.sftp_userauthorizedkeys
     )
     cookbook new_resource.cookbook
     source new_resource.template

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -37,13 +37,15 @@ group node['proftpd-ii']['group'] do
 end
 
 # User created by ProFTPd and no longer needs to be created by us.
-# user node['proftpd-ii']['user'] do
-#  system true
-#  gid node['proftpd-ii']['group']
-#  manage_home false
-#  home node['proftpd-ii']['user_dir']
-#  shell node['proftpd-ii']['user_shell']
-# end
+user node['proftpd-ii']['user'] do
+  system true
+  gid node['proftpd-ii']['group']
+  manage_home false
+  home node['proftpd-ii']['user_dir']
+  shell node['proftpd-ii']['user_shell']
+  notifies :stop, 'service[proftpd]', :before
+  notifies :start, 'service[proftpd]', :immediately
+end
 
 # directories
 directory node['proftpd-ii']['conf_dir'] do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -36,45 +36,46 @@ group node['proftpd-ii']['group'] do
   system true
 end
 
-user node['proftpd-ii']['user'] do
-  system true
-  gid node['proftpd-ii']['group']
-  supports :manage_home => false
-  home node['proftpd-ii']['user_dir']
-  shell node['proftpd-ii']['user_shell']
-end
+# User created by ProFTPd and no longer needs to be created by us.
+# user node['proftpd-ii']['user'] do
+#  system true
+#  gid node['proftpd-ii']['group']
+#  manage_home false
+#  home node['proftpd-ii']['user_dir']
+#  shell node['proftpd-ii']['user_shell']
+# end
 
 # directories
 directory node['proftpd-ii']['conf_dir'] do
   owner node['proftpd-ii']['user']
   group node['proftpd-ii']['group']
-  mode 0755
+  mode 0o755
 end
 
 directory "#{node['proftpd-ii']['conf_dir']}/ssl" do
   owner node['proftpd-ii']['user']
   group node['proftpd-ii']['group']
-  mode 0700
+  mode 0o700
 end
 
-%w(conf sites mods).each do |dir|
+%w[conf sites mods].each do |dir|
   directory "#{node['proftpd-ii']['conf_dir']}/#{dir}-available" do
     owner node['proftpd-ii']['user']
     group node['proftpd-ii']['group']
-    mode 0755
+    mode 0o755
   end
 
   directory "#{node['proftpd-ii']['conf_dir']}/#{dir}-enabled" do
     owner node['proftpd-ii']['user']
     group node['proftpd-ii']['group']
-    mode 0755
+    mode 0o755
   end
 end
 
 directory node['proftpd-ii']['log_dir'] do
   owner node['proftpd-ii']['user']
   group node['proftpd-ii']['group']
-  mode 0755
+  mode 0o755
 end
 
 link "#{node['proftpd-ii']['conf_dir']}/logs" do
@@ -84,26 +85,26 @@ end
 directory node['proftpd-ii']['user_dir'] do
   owner node['proftpd-ii']['user']
   group node['proftpd-ii']['group']
-  mode 0700
+  mode 0o700
 end
 
 # configuration
 template "#{node['proftpd-ii']['conf_dir']}/proftpd.conf" do
   owner node['proftpd-ii']['user']
   group node['proftpd-ii']['group']
-  mode 0640
+  mode 0o640
   source 'proftpd.conf.erb'
   notifies :reload, 'service[proftpd]', :delayed
 end
 
-link "/etc/proftpd.conf" do
+link '/etc/proftpd.conf' do
   to "#{node['proftpd-ii']['conf_dir']}/proftpd.conf"
 end
 
 template "#{node['proftpd-ii']['conf_dir']}/conf-available/global.conf" do
   owner node['proftpd-ii']['user']
   group node['proftpd-ii']['group']
-  mode 0640
+  mode 0o640
   source 'global.conf.erb'
 end
 
@@ -112,12 +113,12 @@ proftpd_conf 'global'
 template "#{node['proftpd-ii']['conf_dir']}/conf-available/tls.conf" do
   owner node['proftpd-ii']['user']
   group node['proftpd-ii']['group']
-  mode 0640
+  mode 0o640
   source 'tls.conf.erb'
 end
 
 # service
 service 'proftpd' do
-  action [ :enable, :start ]
-  supports :status => true, :restart => true, :reload => true
+  action %i[enable start]
+  supports status: true, restart: true, reload: true
 end

--- a/recipes/example_lwrp.rb
+++ b/recipes/example_lwrp.rb
@@ -32,7 +32,7 @@ proftpd_vhost 'ldap' do
   ldap_group_base_dn 'ou=groups,dc=example,dc=com'
   ldap_group_filter '(&(memberUid=%u)(objectclass=posixGroup))'
 
-  options = { 
+  options = {
     'QueryTimeout' => 30,
     'ForceGeneratedHomedir' => 'on'
   }
@@ -48,5 +48,4 @@ proftpd_vhost 'sftp' do
   port 2222
   sftp true
   notifies :restart, 'service[proftpd]', :delayed
-  only_if 'rpm -q proftpd-sftp'
 end

--- a/recipes/force_ssh_keys.rb
+++ b/recipes/force_ssh_keys.rb
@@ -1,0 +1,7 @@
+
+# Enforce 0400 permission on host key files, required by ProFTPd
+node['proftpd-ii']['sftp_hostkeys'].each do |key|
+  file key do
+    mode 0o400
+  end
+end

--- a/recipes/ldap.rb
+++ b/recipes/ldap.rb
@@ -19,5 +19,8 @@
 #
 
 include_recipe 'proftpd-ii'
-package 'proftpd-ldap'
+
+ldap_package_name = 'proftpd-ldap' if node['platform_family'] == 'rhel'
+ldap_package_name = 'proftpd-mod-ldap' if node['platform_family'] != 'rhel'
+package ldap_package_name
 proftpd_module 'ldap'

--- a/recipes/sftp.rb
+++ b/recipes/sftp.rb
@@ -20,9 +20,6 @@
 
 include_recipe 'proftpd-ii'
 
-# since this package has been explicitly required by the inclusion of this recipe, let's fail if it doesn't install
-package 'proftpd-sftp' if node['platform_family'] == 'rhel'
-
 proftpd_module 'sftp' do
 end
 

--- a/recipes/sftp.rb
+++ b/recipes/sftp.rb
@@ -18,26 +18,17 @@
 # limitations under the License.
 #
 
-if not node['platform_family'] == 'rhel'
-  log.error("Your platform_family isn't supported by this recipe. Skipping.")
-  return
-end
-
 include_recipe 'proftpd-ii'
 
-# since this is a custom package, let's make it optional
-package 'proftpd-sftp' do
-  ignore_failure true
-end
+# since this package has been explicitly required by the inclusion of this recipe, let's fail if it doesn't install
+package 'proftpd-sftp' if node['platform_family'] == 'rhel'
 
 proftpd_module 'sftp' do
-  only_if 'rpm -q proftpd-sftp'
 end
 
 template "#{node['proftpd-ii']['conf_dir']}/conf-available/sftp.conf" do
   owner node['proftpd-ii']['user']
   group node['proftpd-ii']['group']
-  mode 0640
+  mode 0o640
   source 'sftp.conf.erb'
-  only_if 'rpm -q proftpd-sftp'
 end

--- a/recipes/sftp.rb
+++ b/recipes/sftp.rb
@@ -20,6 +20,11 @@
 
 include_recipe 'proftpd-ii'
 
+# since this is a custom package, let's make it optional
+package 'proftpd-sftp' do
+  ignore_failure true
+end
+
 proftpd_module 'sftp' do
 end
 

--- a/resources/module.rb
+++ b/resources/module.rb
@@ -21,8 +21,8 @@ provides :proftpd_module
 actions :create, :delete
 default_action :create
 
-attribute :module_dir,        :kind_of => String,                  :default => node['proftpd-ii']['mods_dir']
-attribute :module_name,       :kind_of => String,                  :name_attribute => true
-attribute :enable,            :kind_of => [TrueClass, FalseClass], :default => true
+attribute :module_dir,        kind_of: String,                  default: node['proftpd-ii']['mods_dir']
+attribute :module_name,       kind_of: String,                  name_attribute: true
+attribute :enable,            kind_of: [TrueClass, FalseClass], default: true
 
 attr_accessor :exists

--- a/resources/vhost.rb
+++ b/resources/vhost.rb
@@ -21,39 +21,39 @@ provides :proftpd_vhost
 actions :create, :delete
 default_action :create
 
-attribute :bind,              :kind_of => String,                  :default => '0.0.0.0'
-attribute :port,              :kind_of => Integer,                 :default => node['proftpd-ii']['port']
-attribute :auth_order,        :kind_of => String,                  :default => node['proftpd-ii']['auth_order']
-attribute :default_server,    :kind_of => String,                  :default => false
+attribute :bind,              kind_of: String,                  default: '0.0.0.0'
+attribute :port,              kind_of: Integer,                 default: node['proftpd-ii']['port']
+attribute :auth_order,        kind_of: String,                  default: node['proftpd-ii']['auth_order']
+attribute :default_server,    kind_of: [TrueClass, FalseClass], default: false
 
-attribute :enable,            :kind_of => [TrueClass, FalseClass], :default => true
-attribute :cookbook,          :kind_of => String,                  :default => 'proftpd-ii'
-attribute :template,          :kind_of => String,                  :default => 'vhost.conf.erb'
-attribute :default_root,      :kind_of => String,                  :default => node['proftpd-ii']['default_root']
+attribute :enable,            kind_of: [TrueClass, FalseClass], default: true
+attribute :cookbook,          kind_of: String,                  default: 'proftpd-ii'
+attribute :template,          kind_of: String,                  default: 'vhost.conf.erb'
+attribute :default_root,      kind_of: String,                  default: node['proftpd-ii']['default_root']
 
-attribute :log_dir,           :kind_of => String,                  :default => node['proftpd-ii']['log_dir']
-attribute :debug_level,       :kind_of => Integer,                 :default => node['proftpd-ii']['debug_level']
+attribute :log_dir,           kind_of: String,                  default: node['proftpd-ii']['log_dir']
+attribute :debug_level,       kind_of: Integer,                 default: node['proftpd-ii']['debug_level']
 
-attribute :tls,               :kind_of => [TrueClass, FalseClass], :default => false
-attribute :tls_required,      :kind_of => [TrueClass, FalseClass], :default => true
-attribute :tls_cert,          :kind_of => String,                  :default => nil
-attribute :tls_key,           :kind_of => String,                  :default => nil
-attribute :tls_chain,         :kind_of => String,                  :default => false
-attribute :tls_verify_client, :kind_of => [TrueClass, FalseClass], :default => false
+attribute :tls,               kind_of: [TrueClass, FalseClass], default: false
+attribute :tls_required,      kind_of: [TrueClass, FalseClass], default: true
+attribute :tls_cert,          kind_of: String,                  default: nil
+attribute :tls_key,           kind_of: String,                  default: nil
+attribute :tls_chain,         kind_of: String,                  default: nil
+attribute :tls_verify_client, kind_of: [TrueClass, FalseClass], default: false
 
-attribute :ldap,              :kind_of => [TrueClass, FalseClass], :default => false
-attribute :ldap_use_tls,      :kind_of => [TrueClass, FalseClass], :default => true
-attribute :ldap_server,       :kind_of => String,                  :default => nil
-attribute :ldap_bind_auth,    :kind_of => [TrueClass, FalseClass], :default => false
-attribute :ldap_bind_dn,      :kind_of => String,                  :default => nil
-attribute :ldap_bind_pass,    :kind_of => String,                  :default => nil
-attribute :ldap_user_base_dn, :kind_of => String,                  :default => nil
-attribute :ldap_user_filter,  :kind_of => String,                  :default => nil
-attribute :ldap_group_base_dn,:kind_of => String,                  :default => nil
-attribute :ldap_group_filter, :kind_of => String,                  :default => nil
-attribute :ldap_extra_options,:kind_of => Hash,                    :default => {}
+attribute :ldap,              kind_of: [TrueClass, FalseClass], default: false
+attribute :ldap_use_tls,      kind_of: [TrueClass, FalseClass], default: true
+attribute :ldap_server,       kind_of: String,                  default: nil
+attribute :ldap_bind_auth,    kind_of: [TrueClass, FalseClass], default: false
+attribute :ldap_bind_dn,      kind_of: String,                  default: nil
+attribute :ldap_bind_pass,    kind_of: String,                  default: nil
+attribute :ldap_user_base_dn, kind_of: String,                  default: nil
+attribute :ldap_user_filter,  kind_of: String,                  default: nil
+attribute :ldap_group_base_dn, kind_of: String, default: nil
+attribute :ldap_group_filter, kind_of: String, default: nil
+attribute :ldap_extra_options, kind_of: Hash, default: {}
 
-attribute :sftp,              :kind_of => [TrueClass, FalseClass], :default => false
-attribute :sftp_userauthorizedkeys, :kind_of => String, :default => nil
+attribute :sftp,              kind_of: [TrueClass, FalseClass], default: false
+attribute :sftp_userauthorizedkeys, kind_of: String, default: nil
 
 attr_accessor :exists

--- a/templates/default/sftp.conf.erb
+++ b/templates/default/sftp.conf.erb
@@ -4,8 +4,11 @@
 
   # Configure both the RSA and DSA host keys, using the same host key
   # files that OpenSSH uses.
-  SFTPHostKey /etc/ssh/ssh_host_rsa_key
-  SFTPHostKey /etc/ssh/ssh_host_dsa_key
+  <%
+  node['proftpd-ii']['sftp_hostkeys'].each do | key |
+  %>
+  SFTPHostKey <%= key %>
+  <% end %>
 
 <% if node['proftpd-ii']['sftp_userauthorizedkeys'] %>
     # Permit AuthorizedKeys files for users to login using keys

--- a/templates/default/vhost.conf.erb
+++ b/templates/default/vhost.conf.erb
@@ -25,7 +25,7 @@
   </IfModule>
 <% end %>
 
-<% if @ldap %> 
+<% if @ldap %>
   <IfModule mod_ldap.c>
     LDAPUseTLS                              <% if @ldap_use_tls %>on<% else %>off<% end %>
     LDAPServer                              <%= @ldap_server %>
@@ -46,11 +46,14 @@
   <IfModule mod_sftp.c>
     SFTPEngine on
     SFTPLog <%= node['proftpd-ii']['log_dir'] %>/sftp.log
-  
+
     # Configure both the RSA and DSA host keys, using the same host key
     # files that OpenSSH uses.
-    SFTPHostKey /etc/ssh/ssh_host_rsa_key
-    SFTPHostKey /etc/ssh/ssh_host_dsa_key
+    <%
+    node['proftpd-ii']['sftp_hostkeys'].each do | key |
+    %>
+    SFTPHostKey <%= key %>
+    <% end %>
 
 <% if @sftp_userauthorizedkeys %>
     # Permit AuthorizedKeys files for users to login using keys

--- a/test/smoke/default/default_spec.rb
+++ b/test/smoke/default/default_spec.rb
@@ -1,0 +1,15 @@
+describe port(21) do
+  it { should be_listening }
+  its('processes') { should include 'proftpd' }
+end
+
+describe service('proftpd') do
+  it { should be_installed }
+  it { should be_enabled }
+  it { should be_running }
+end
+
+describe port(2222) do
+  it { should be_listening }
+  its('processes') { should include 'proftpd' }
+end


### PR DESCRIPTION
Hi!
I wanted to use your cookbook for Debian, but found it only supported RHEL platforms.
I've added Test Kitchen + some basic inspec tests so you can validate what I've done easily using `kitchen test`.
Most of the changes are syntactic by Rubocop for style, but the substantive changes I've made are.

1. Add test kitchen tests
2. Forced the stop and start of the prodftpd service when updating the proftpd user
3. Removed the guards around the LWRPs for validating that the SFTP package was installed as it was RHEL specific and my logic is that if we're running the SFTP recipe we shouldn't be relying on whether or not the package is installed for configuring SFTP. (Especially as SFTP works even without that package.)
4. added an attribute `node['proftpd-ii']['sftp_hostkeys']` as Ubuntu and Debian only come with RSA keys.

If I've missed the point of anything, do let me know as I'm keen to get this merged and use your cookbook officially!

Many thanks,

Sam